### PR TITLE
Fix the problem where the game will not run if only one scene included

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -23,7 +23,7 @@ namespace gamejam {
         _win = false;
         _debug = true;
         _current = 0;
-        if (_current < _scenes.length - 1) {
+        if (_current <= _scenes.length - 1) {
             storyboard.push(_scenes[_current]);
             start();
         }

--- a/pxt.json
+++ b/pxt.json
@@ -15,7 +15,7 @@
     ],
     "public": false,
     "targetVersions": {
-        "target": "1.2.16",
+        "target": "1.11.37",
         "targetId": "arcade"
     },
     "supportedTargets": [


### PR DESCRIPTION
Changed one line so that the program will run when there is only one scene included in the game. Before, you needed a minimum of two scenes otherwise the init() function would not load.